### PR TITLE
Let us pass flags when the window is created

### DIFF
--- a/pyqt_frameless_window/base/baseWidget.py
+++ b/pyqt_frameless_window/base/baseWidget.py
@@ -22,13 +22,16 @@ class BaseWidget(QWidget):
         self._originalY = 0
         self._originalHeightBeforeExpand = 0
 
-    def _initUi(self, hint):
+    def _initUi(self, hint, flags):
         self._initPosition()
-        self._initBasicUi(hint)
+        self._initBasicUi(hint, flags)
 
-    def _initBasicUi(self, hint):
+    def _initBasicUi(self, hint, flags):
         self.setMouseTracking(True)
-        self.setWindowFlags(Qt.Window | Qt.FramelessWindowHint | Qt.WindowMinMaxButtonsHint)
+        newFlags = Qt.Window | Qt.FramelessWindowHint | Qt.WindowMinMaxButtonsHint
+        for flag in flags:
+            newFlags |= flag
+        self.setWindowFlags(newFlags)
         # self._titleBar = TitleBar(self, hint)
 
     # init the edge direction for set correct reshape cursor based on it

--- a/pyqt_frameless_window/framelessWindow.py
+++ b/pyqt_frameless_window/framelessWindow.py
@@ -13,13 +13,13 @@ from qtpy.QtCore import Signal
 class FramelessWidget(BaseWidget):
     changedToDark = Signal(bool)
 
-    def __init__(self, hint=None):
+    def __init__(self, hint=None, flags: list = []):
         super().__init__()
         self._initVal()
-        self._initUi(hint)
+        self._initUi(hint, flags)
 
-    def _initUi(self, hint):
-        super()._initUi(hint)
+    def _initUi(self, hint, flags):
+        super()._initUi(hint, flags)
         lay = QVBoxLayout()
         lay.addWidget(self._titleBar)
         lay.setContentsMargins(0, 0, 0, 0)
@@ -29,13 +29,13 @@ class FramelessWidget(BaseWidget):
 
 class FramelessDialog(QDialog, BaseWidget):
     changedToDark = Signal(bool)
-    def __init__(self, hint=None):
+    def __init__(self, hint=None, flags: list = []):
         super().__init__()
         self._initVal()
-        self._initUi(hint)
+        self._initUi(hint, flags)
 
-    def _initUi(self, hint):
-        super()._initUi(hint)
+    def _initUi(self, hint, flags):
+        super()._initUi(hint, flags)
         lay = QVBoxLayout()
         lay.addWidget(self._titleBar)
         lay.setContentsMargins(0, 0, 0, 0)
@@ -45,13 +45,13 @@ class FramelessDialog(QDialog, BaseWidget):
 
 class FramelessMainWindow(QMainWindow, BaseWidget):
     changedToDark = Signal(bool)
-    def __init__(self, hint=None):
+    def __init__(self, hint=None, flags: list = []):
         super().__init__()
         self._initVal()
-        self._initUi(hint)
+        self._initUi(hint, flags)
 
-    def _initUi(self, hint):
-        super()._initUi(hint)
+    def _initUi(self, hint, flags):
+        super()._initUi(hint, flags)
         lay = QVBoxLayout()
         lay.addWidget(self._titleBar)
         lay.setContentsMargins(0, 0, 0, 0)

--- a/pyqt_frameless_window/windows/baseWidget.py
+++ b/pyqt_frameless_window/windows/baseWidget.py
@@ -31,14 +31,17 @@ class BaseWidget(QWidget):
         # define in advance to prevent AttributeError
         self._titleBar = ''
 
-    def _initUi(self, hint=None):
+    def _initUi(self, hint=None, flags: list = []):
         if hint is None:
             hint = ['min', 'max', 'close']
         self._windowEffect = WindowsEffectHelper()
 
         # remove window border
         # seems kinda pointless(though if you get rid of code below frame will still be seen), but if you don't add this, cursor won't properly work
-        self.setWindowFlags(self.windowFlags() | Qt.FramelessWindowHint)
+        newFlags = self.windowFlags() | Qt.FramelessWindowHint
+        for flag in flags:
+            newFlags |= flag
+        self.setWindowFlags(newFlags)
 
         # add DWM shadow and window animation
         self._windowEffect.setBasicEffect(self.winId(), hint)


### PR DESCRIPTION
This is the only way I found to make sure that everything is working properly, otherwise the window will not work properly if you try to add another flag (e.g. `Qt.WindowStaysOnTopHint`) from your window.

*Code which isn't working:*
```py
class MyWindow(FramelessMainWindow):
    def __init__(self):
        super().__init__()
        self.setWindowFlags(self.windowFlags() | Qt.WindowStaysOnTopHint)
```

*Now:*
```py
class MyWindow(FramelessMainWindow):
    def __init__(self):
        super().__init__(flags = [Qt.WindowStaysOnTopHint])
```

***Note: I only tested `FramelessMainWindow`***

Hope everything is fine for you :D